### PR TITLE
Add request start

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "Trucha",
+    platforms: [.macOS(.v11), .iOS(.v14)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/Tests/TruchaTests/TruchaRequestTests.swift
+++ b/Tests/TruchaTests/TruchaRequestTests.swift
@@ -1,0 +1,54 @@
+//
+//  TruchaRequestTests.swift
+//  
+//
+//  Created by Juan Hurtado on 22/07/23.
+//
+
+import XCTest
+@testable import Trucha
+
+final class TruchaRequestTests: XCTestCase {
+    let basePath = "https://foo.bar"
+    
+    func testRequestUrl_withBasePathSet_shouldBeEqualToTheSumOfBasePathAndItsPath() {
+        Trucha.sharedClient.setBasePath(basePath)
+        let path = "/trucha"
+        let request = Trucha.sharedClient.request(path)
+        XCTAssertNotNil(request)
+        XCTAssertEqual(request!.url.absoluteString, basePath + path)
+    }
+    
+    func testRequestInit_WithInvalidPath_shouldThrow() {
+        let invalidPath = "this_is_an_invalid_path"
+        do {
+            let _ = try TruchaRequest(path: invalidPath)
+        } catch {
+            guard let truchaError = error as? TruchaError else {
+                XCTFail("wrong error thrown!!")
+                return
+            }
+            XCTAssertEqual(truchaError, .invalidURL)
+        }
+    }
+    
+    func testRequestInitViaClient_withInvalidPathAndBasePath_shouldBeNil() {
+        Trucha.sharedClient.setBasePath(basePath)
+        let invalidPath = "th1s_is an_invalid_p4th"
+        let request = Trucha.sharedClient.request(invalidPath)
+        XCTAssertNil(request)
+    }
+    
+    func testRequestInitViaClient_withUrlWithoutBasePath_shouldInitSuccessfuly() {
+        let rawUrl = "https://bar.co"
+        let request = Trucha.sharedClient.request(rawUrl)
+        XCTAssertNotNil(request)
+    }
+    
+    func testRequestStart_withValidUrl_shouldReturnResponse() async throws {
+        let url = "https://api.publicapis.org/entries"
+        let request = Trucha.sharedClient.request(url)
+        let response = try? await request?.start()
+        XCTAssertNotNil(response)
+    }
+}

--- a/Tests/TruchaTests/TruchaRequestTests.swift
+++ b/Tests/TruchaTests/TruchaRequestTests.swift
@@ -11,6 +11,10 @@ import XCTest
 final class TruchaRequestTests: XCTestCase {
     let basePath = "https://foo.bar"
     
+    override func setUp() {
+        Trucha.sharedClient.clear()
+    }
+    
     func testRequestUrl_withBasePathSet_shouldBeEqualToTheSumOfBasePathAndItsPath() {
         Trucha.sharedClient.setBasePath(basePath)
         let path = "/trucha"

--- a/Tests/TruchaTests/TruchaTests.swift
+++ b/Tests/TruchaTests/TruchaTests.swift
@@ -4,53 +4,9 @@ import XCTest
 final class TruchaTests: XCTestCase {
     let basePath = "https://foo.bar"
     
-    override func setUp() {
-        Trucha.sharedClient.clear()
-    }
-    
-    func test_sharedClientBasePath_shouldBeEqualToTheOneProvided() {
+
+    func testSharedClientBasePath_withProvidedBasePath_shouldBeEqualToTheOneProvided() {
         Trucha.sharedClient.setBasePath(basePath)
         XCTAssertEqual(Trucha.sharedClient.basePath, basePath)
-    }
-    
-    func test_requestUrlshouldBeEqualToTheSumOfBasePathAndItsPath() {
-        Trucha.sharedClient.setBasePath(basePath)
-        let path = "/trucha"
-        let request = Trucha.sharedClient.request(path)
-        XCTAssertNotNil(request)
-        XCTAssertEqual(request!.url.absoluteString, basePath + path)
-    }
-    
-    func test_requestInitWithInvalidPath_shouldThrow() {
-        let invalidPath = "this_is_an_invalid_path"
-        do {
-            let _ = try TruchaRequest(path: invalidPath)
-        } catch {
-            guard let truchaError = error as? TruchaError else {
-                XCTFail("wrong error thrown!!")
-                return
-            }
-            XCTAssertEqual(truchaError, .invalidURL)
-        }
-    }
-    
-    func test_requestInitViaClientWithInvalidPathAndBasePath_shouldBeNil() {
-        Trucha.sharedClient.setBasePath(basePath)
-        let invalidPath = "th1s_is an_invalid_p4th"
-        let request = Trucha.sharedClient.request(invalidPath)
-        XCTAssertNil(request)
-    }
-    
-    func test_requestInitViaClientWithUrlWithoutBasePath_shouldInitSuccessfuly() {
-        let rawUrl = "https://bar.co"
-        let request = Trucha.sharedClient.request(rawUrl)
-        XCTAssertNotNil(request)
-    }
-    
-    func testRequestStart_withValidUrl_shouldReturnResponse() async throws {
-        let url = "https://api.publicapis.org/entries"
-        let request = Trucha.sharedClient.request(url)
-        let response = try? await request?.start()
-        XCTAssertNotNil(response)
     }
 }

--- a/Tests/TruchaTests/TruchaTests.swift
+++ b/Tests/TruchaTests/TruchaTests.swift
@@ -46,4 +46,11 @@ final class TruchaTests: XCTestCase {
         let request = Trucha.sharedClient.request(rawUrl)
         XCTAssertNotNil(request)
     }
+    
+    func testRequestStart_withValidUrl_shouldReturnResponse() async throws {
+        let url = "https://api.publicapis.org/entries"
+        let request = Trucha.sharedClient.request(url)
+        let response = try? await request?.start()
+        dump(response)
+    }
 }

--- a/Tests/TruchaTests/TruchaTests.swift
+++ b/Tests/TruchaTests/TruchaTests.swift
@@ -51,6 +51,6 @@ final class TruchaTests: XCTestCase {
         let url = "https://api.publicapis.org/entries"
         let request = Trucha.sharedClient.request(url)
         let response = try? await request?.start()
-        dump(response)
+        XCTAssertNotNil(response)
     }
 }


### PR DESCRIPTION
* Now a request can be started.
* Moved request unit tests to its own file.